### PR TITLE
Added --port option to hpilo_cli to allow for non-standard iLO settings.

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -30,14 +30,14 @@ class Ilo(object):
     XML_HEADER = '<?xml version="1.0"?>\r\n'
     HTTP_HEADER = "POST /ribcl HTTP/1.1\r\nHost: localhost\r\nContent-length: %d\r\nConnection: Close\r\n\r\n"
 
-    def __init__(self, hostname, login, password, timeout=60):
+    def __init__(self, hostname, login, password, timeout=60, port=443):
         self.hostname = hostname
         self.login = login
         self.password = password
         self.timeout  = timeout
         self.debug    = 0
         self.protocol = None
-        self.port     = 443
+        self.port     = port
 
     def __str__(self):
         return "iLO interface of %s" % self.hostname

--- a/hpilo_cli
+++ b/hpilo_cli
@@ -35,6 +35,8 @@ Supported methods:
                  help="Use the specified protocol instead of autodetecting")
     p.add_option("-d", "--debug", dest="debug", action="count", default=0,
                  help="Output debug information, repeat to see all XML data")
+    p.add_option("-o", "--port", dest="port", type="int", default=443,
+                 help="SSL port to connect to")
     p.add_option("-h", "--help", action="callback", callback=hpilo_help,
                  help="show this help message or help for a method")
 
@@ -99,7 +101,7 @@ Supported methods:
         p.print_help()
         p.exit()
 
-    ilo = hpilo.Ilo(hostname, login, password, opts.timeout)
+    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port)
     ilo.debug = opts.debug
     if opts.protocol == 'http':
         ilo.protocol = hpilo.ILO_HTTP


### PR DESCRIPTION
I added a --port option to hpilo_cli so that I can use SSH port-forwarding to access my iLO's.
I used '-o' for the short option flag as '-p/--password' and '-P/--protocol' were already used.

Thanks for your work! From my limited testing (mainly read-only operations) it seems to work rather well.

Hardware tested:
- HP SL390s G7
- HP SL335s G7
- HP DL380 G7

Andrew
