### PR TITLE
Fix case where returntags is None causes an iteration error

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -458,13 +458,21 @@ class Ilo(object):
         fd.close()
         return ret
 
-    def _info_tag(self, infotype, tagname, returntag=None, attrib={}):
+    def _info_tag(self, infotype, tagname, returntags=None, attrib={}):
         root, inner = self._root_element(infotype, MODE='read')
         etree.SubElement(inner, tagname, **attrib)
         header, message = self._request(root)
-        if isinstance(returntag, basestring):
-            returntag = [returntag or tagname]
-        for tag in returntag:
+
+        # Use tagname as returntags if returntags isn't specificed
+        if isinstance(returntags, basestring):
+            returntags = [returntags]
+        elif returntags is None:
+            if isinstance(tagname, basestring):
+                returntags = [tagname]
+            else:
+                returntags = tagname
+
+        for tag in returntags:
             if not message.find(tag):
                 continue
             message = message.find(tag)
@@ -472,7 +480,7 @@ class Ilo(object):
                 return self._element_children_to_dict(message)
             else:
                 return self._element_to_dict(message)
-        raise IloError("Expected tag '%s' not found" % "' or '".join(returntag))
+        raise IloError("Expected tag '%s' not found" % "' or '".join(returntags))
 
     def _info_tag2(self, infotype, tagname, returntag=None, key=None):
         root, inner = self._root_element(infotype, MODE='read')


### PR DESCRIPTION
Before:

```
(provisioning)[kevin@...]~/workspace/ilo/python-hpilo% ./hpilo_cli -i -l example example.net.1918.berkeley.edu get_network_settings
Password for example@example.net.1918.berkeley.edu:


Traceback (most recent call last):
  File "./hpilo_cli", line 213, in <module>
    main()
  File "./hpilo_cli", line 155, in main
    result = getattr(ilo, method)(**params)
  File "/Users/kevin/workspace/ilo/python-hpilo/hpilo.py", line 699, in get_network_settings
    return self._info_tag('RIB_INFO', 'GET_NETWORK_SETTINGS')
  File "/Users/kevin/workspace/ilo/python-hpilo/hpilo.py", line 468, in _info_tag
    for tag in returntag:
TypeError: 'NoneType' object is not iterable
```

After:

```
(provisioning)[kevin@...]~/workspace/ilo/python-hpilo% ./hpilo_cli -i -l example example.net.1918.berkeley.edu get_network_settings
Password for example@example.1918.berkeley.edu:
>>> pprint(my_ilo.get_network_settings())
{'dhcp_dns_server': True,
 'dhcp_domain_name': True,
 'dhcp_enable': False,
 [...]
```
