### PR TITLE
Permit the use of & characters in passwords

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -185,6 +185,11 @@ class Ilo(object):
         else:
             xml = etree.tostring(xml)
 
+        # XML doesn't support ampersand (&) characters un-escaped, but the HP iLO permits
+        # this as a valid password character. ElementTree helpfully escapes & to &amp; thus
+        # breaking passwords containing this character. Undo its good work.
+        xml = xml.replace('&amp;', '&')
+
         header, data =  self._communicate(xml, self.protocol, progress=progress)
 
         # This thing usually contains multiple XML messages


### PR DESCRIPTION
As per the comments, the HP iLOs support '&' in passwords, whereas this is a special character in XML. ElementTree escapes the & character into &amp; which causes a 'login failed' error.

The closest actual reference I can find from HP on this is in HP advisory document c03221572.
