### PR TITLE
Make set_server_name work with iLO 4 - 2.03

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -1635,7 +1635,7 @@ class Ilo(object):
 
     def set_server_name(self, name):
         """Set the name of the server"""
-        return self._control_tag('SERVER_INFO', 'SERVER_NAME', attrib={"VALUE": name})
+        return self._control_tag('SERVER_INFO', 'SERVER_NAME', attrib={"value": name})
 
     def set_vf_status(self, boot_option="boot_once", write_protect=True):
         """Set the parameters of the RILOE virtual floppy specified virtual


### PR DESCRIPTION
The Gen9 ilo versions have a bug/feature that set_server_name only works with a lower-case "value". An upper-case "VALUE" triggers a syntax error. Curiously only this command seems to be affected, all the others I've tried seem to be fine.