### PR TITLE
Simplify the use of snmp_address_1_trapcommunity through a string

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -1398,10 +1398,13 @@ class Ilo(object):
                     for x in vars if vars[x] is not None and 'trapcommunity' not in x and 'snmp_user_profile' not in x]
         for key in vars:
             if 'trapcommunity' in key and vars[key]:
-                val = vars[key]
-                for key_ in val.keys():
-                    val[key_.upper()] = str(val.pop(key_))
-                elements.append(etree.Element(key.upper(), **val))
+                if type(vars[key]) is str:
+                    vals = { 'VALUE': vars[key] }  
+                    vals['VERSION']=''
+                else:  # A dict
+                    for key_ in val.keys():
+                       vals[key_.upper()] = str(val.pop(key_))
+                elements.append(etree.Element(key.upper(), **vals))
             elif 'snmp_user_profile' in key and vars[key]:
                 elt = etree.Element(key[:-2].upper(), {'INDEX': key[-1]})
                 for key, val in vars[key].items():

--- a/hpilo.py
+++ b/hpilo.py
@@ -1402,8 +1402,9 @@ class Ilo(object):
                     vals = { 'VALUE': vars[key] }  
                     vals['VERSION']=''
                 else:  # A dict
-                    for key_ in val.keys():
-                       vals[key_.upper()] = str(val.pop(key_))
+                    vals = vars[key]
+                    for key_ in vals.keys():
+                       vals[key_.upper()] = str(vals.pop(key_))
                 elements.append(etree.Element(key.upper(), **vals))
             elif 'snmp_user_profile' in key and vars[key]:
                 elt = etree.Element(key[:-2].upper(), {'INDEX': key[-1]})


### PR DESCRIPTION
Currently snmp_address_1_trapcommunity does not actively use the version string
as of Ilo4 version 2.10

Retrieving the parameter through RIBCL xml provides an empty version string.
Sample:
<SNMP_ADDRESS_1_TRAPCOMMUNITY VERSION="" VALUE="MY_COMMUNITY"/>

So better use a string to set the parameter.
It ease the use of the parameter though command line cli (I do not even
have a clue on how to pass a dictionnary on the cli).
This patch still maintains the dictionnary compatibility.