### PR TITLE
Workaround for socket_shutdown error on OS X

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -432,7 +432,13 @@ class Ilo(object):
             sock.stdout.close()
             sock.wait()
         elif sock.shutdown:
-            sock.shutdown(socket.SHUT_RDWR)
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except socket.error:
+                if platform.system() == "Darwin":
+                    pass
+                else:
+                    raise
             sock.close()
         if self.save_response:
             fd = open(self.save_response, 'a')

--- a/hpilo.py
+++ b/hpilo.py
@@ -2,6 +2,7 @@
 # see COPYING for license details
 
 import os
+import errno
 import platform
 import random
 import re
@@ -434,8 +435,8 @@ class Ilo(object):
         elif sock.shutdown:
             try:
                 sock.shutdown(socket.SHUT_RDWR)
-            except socket.error:
-                if platform.system() == "Darwin":
+            except socket.error as e:
+                if e.errno == errno.ENOTCONN:
                     pass
                 else:
                     raise


### PR DESCRIPTION
This change catches and suppresses the exception raised when
socket_shutdown is called on os X. The possible cause is a race
condition where the socket may already have been shut down as suggested
at https://code.google.com/p/py-amqplib/issues/detail?id=45

Proposed fix for https://github.com/seveas/python-hpilo/issues/76