### PR TITLE
Update firmware.conf - add iLo4 2.31

### DIFF
--- a/firmware.conf
+++ b/firmware.conf
@@ -423,3 +423,7 @@ version = 2.30
 url = http://ftp.hp.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v106715/CP026236.scexe
 file = ilo4_230.bin
 
+[ilo4 2.31]
+version = 2.31
+url = http://ftp.hp.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v112690/CP027992.scexe
+file = ilo4_231.bin


### PR DESCRIPTION
- add iLo4 2.31
 - BUILD DATE:  September 29,2015
 - EFFECTIVE DATE:  October 7, 2015
 - Fixes: `Fixed an issue where the SPI bus could lock up causing iLO and the host server to become unresponsive if iLO is rebooted while the server is in early POST.`