### PR TITLE
Added support for TLSv1, TLSv1_1 and TLSv1_2, using a new argument -s…

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -7,7 +7,7 @@ The :py:mod:`hpilo` module contains all you need to communicate with iLO
 devices, encapsulated in the :class:`Ilo` class and its methods. There are a
 few auxiliarry items in this module too.
 
-.. py:class:: Ilo(hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False)
+.. py:class:: Ilo(hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False, ssl_version=None)
 
    Represents an iLO management interface on a specific host.
 
@@ -25,6 +25,10 @@ few auxiliarry items in this module too.
                    for any method call you make and return a result. To save
                    roundtrip time costs, set this to :py:data:`False` and call
                    the :py:meth:`call_delayed` method manually.
+   :param ssl_version: By default, this library will use the TLSv1 protocol as
+                   security layer, unless you specify this parameter.
+                   If you do not specify it then SSL3 will be used as fallback
+                   in case of SSL problems. Possible values are: ssl3, tls1, tls1_1, tls1_2
 
    .. py:method:: call_delayed
 
@@ -39,6 +43,11 @@ few auxiliarry items in this module too.
            'management_processor': 'iLO3'}
           >>> pprint(ilo.get_uid_status())
           'OFF'
+          >>> ilo = hpilo.Ilo('example-server.int.kaarsemaker.net', 'Administrator', 'PassW0rd', ssl_version=ssl.PROTOCOL_TLS1_2)
+          {'firmware_date': 'Dec 02 2015',
+           'firmware_version': '2.40',
+           'license_type': 'iLO Standard',
+           'management_processor': 'iLO4'}
 
       and
 

--- a/docs/shell.rst
+++ b/docs/shell.rst
@@ -19,25 +19,26 @@ Contacts the iLO, calls one or more methods and displays the output as if you
 were using a python console.
 
 Options:
-    -l LOGIN, --login=LOGIN
-                          Username to access the iLO
-    -p PASSWORD, --password=PASSWORD
-                          Password to access the iLO
-    -i, --interactive     Prompt for username and/or password if they are not
-                          specified.
-    -c FILE, --config=FILE
-                          File containing authentication and config details
-    -t TIMEOUT, --timeout=TIMEOUT
-                          Timeout for iLO connections
-    -j, --json            Output a json document instead of a python dict
-    -y, --yaml            Output a yaml document instead of a python dict
-    -P PROTOCOL, --protocol=PROTOCOL
-                          Use the specified protocol instead of autodetecting
-    -d, --debug           Output debug information, repeat to see all XML data
-    -o PORT, --port=PORT  SSL port to connect to
-    --untested            Allow untested methods
-    -h, --help            show this help message or help for a method
-    -H, --help-methods    show all supported methods
+  -l LOGIN, --login=LOGIN
+                        Username to access the iLO
+  -p PASSWORD, --password=PASSWORD
+                        Password to access the iLO
+  -i, --interactive     Prompt for username and/or password if they are not
+                        specified.
+  -c FILE, --config=FILE
+                        File containing authentication and config details
+  -t TIMEOUT, --timeout=TIMEOUT
+                        Timeout for iLO connections
+  -j, --json            Output a json document instead of a python dict
+  -y, --yaml            Output a yaml document instead of a python dict
+  -P PROTOCOL, --protocol=PROTOCOL
+                        Use the specified protocol instead of autodetecting
+  -d, --debug           Output debug information, repeat to see all XML data
+  -o PORT, --port=PORT  SSL port to connect to
+  -s SSL_VERSION, --ssl=SSL_VERSION
+                        The SSL/TLS version to use for connecting to the iLO
+  -h, --help            show this help message or help for a method
+  -H, --help-methods    show all supported methods
 
 :program:`hpilo_cli` will read a config file (by default :file:`~/.ilo.conf`)
 to find login information and any other variable you wish to set. This config

--- a/hpilo.py
+++ b/hpilo.py
@@ -36,6 +36,8 @@ except ImportError:
         PROTOCOL_SSLv3 = 1
         PROTOCOL_TLSv23 = 2
         PROTOCOL_TLSv1 = 3
+        PROTOCOL_TLSv1_1 = 4
+        PROTOCOL_TLSv1_2 = 5
         @staticmethod
         def wrap_socket(sock, *args, **kwargs):
             return ssl(sock)
@@ -183,7 +185,7 @@ class Ilo(object):
     HTTP_UPLOAD_HEADER = "POST /cgi-bin/uploadRibclFiles HTTP/1.1\r\nHost: localhost\r\nConnection: Close\r\nContent-Length: %d\r\nContent-Type: multipart/form-data; boundary=%s\r\n\r\n"
     BLOCK_SIZE = 64 * 1024
 
-    def __init__(self, hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False):
+    def __init__(self, hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False, ssl_version="PROTOCOL_TLSv1"):
         self.hostname = hostname
         self.login    = login or 'Administrator'
         self.password = password or 'Password'
@@ -195,7 +197,7 @@ class Ilo(object):
         self.delayed  = delayed
         self._elements = None
         self._processors = []
-        self.ssl_version = ssl.PROTOCOL_TLSv1
+        self.ssl_version = getattr(ssl, ssl_version, ssl.PROTOCOL_TLSv1)
         self.save_response = None
         self.read_response = None
         self.save_request = None
@@ -1934,3 +1936,4 @@ class Ilo(object):
         'fan': ('bay',),
         'powersupply': ('bay', 'diag'),
     }
+

--- a/hpilo.py
+++ b/hpilo.py
@@ -33,9 +33,9 @@ try:
 except ImportError:
     # Fallback for older python versions
     class ssl:
-        PROTOCOL_SSLv3 = 1
-        PROTOCOL_TLSv23 = 2
-        PROTOCOL_TLSv1 = 3
+        PROTOCOL_SSLv3   = 1
+        PROTOCOL_TLSv23  = 2
+        PROTOCOL_TLSv1   = 3
         PROTOCOL_TLSv1_1 = 4
         PROTOCOL_TLSv1_2 = 5
         @staticmethod
@@ -59,6 +59,13 @@ except ImportError:
 
         def close(self):
             return self.sock.close()
+
+SSL_VERSION = {
+    "ssl3"   : ssl.PROTOCOL_SSLv3,
+    "tls1"   : ssl.PROTOCOL_TLSv1,
+    "tls1_1" : ssl.PROTOCOL_TLSv1_1,
+    "tls1_2" : ssl.PROTOCOL_TLSv1_2,
+}
 
 try:
     import xml.etree.ElementTree as etree
@@ -185,19 +192,20 @@ class Ilo(object):
     HTTP_UPLOAD_HEADER = "POST /cgi-bin/uploadRibclFiles HTTP/1.1\r\nHost: localhost\r\nConnection: Close\r\nContent-Length: %d\r\nContent-Type: multipart/form-data; boundary=%s\r\n\r\n"
     BLOCK_SIZE = 64 * 1024
 
-    def __init__(self, hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False, ssl_version="PROTOCOL_TLSv1"):
+    def __init__(self, hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False, ssl_version=None):
         self.hostname = hostname
         self.login    = login or 'Administrator'
         self.password = password or 'Password'
         self.timeout  = timeout
         self.debug    = 0
         self.port     = port
+        self.ssl_version = ssl_version if ssl_version in SSL_VERSION.values() else ssl.PROTOCOL_TLSv1
+        self.ssl_fallback = self.ssl_version != ssl_version
         self.protocol = protocol
         self.cookie   = None
         self.delayed  = delayed
         self._elements = None
         self._processors = []
-        self.ssl_version = getattr(ssl, ssl_version, ssl.PROTOCOL_TLSv1)
         self.save_response = None
         self.read_response = None
         self.save_request = None
@@ -399,9 +407,11 @@ class Ilo(object):
             e = sys.exc_info()[1]
             msg = getattr(e, 'reason', None) or getattr(e, 'message', None) or str(e)
             # Some ancient iLO's don't support TLSv1, retry with SSLv3
-            if 'wrong version number' in msg and self.sslversion == ssl.PROTOCOL_TLSv1:
-                self.ssl_version = ssl.PROTOCOL_SSLv3
-                return self._get_socket()
+            # iff the ssl_version argument where not specified on the command line.
+            if self.ssl_fallback:
+				if 'wrong version number' in msg and self.sslversion >= ssl.PROTOCOL_TLSv1:
+					self.ssl_version = ssl.PROTOCOL_SSLv3
+					return self._get_socket()
             raise IloCommunicationError("Cannot establish ssl session with %s:%d: %s" % (self.hostname, self.port, msg))
 
     def _communicate(self, xml, protocol, progress=None, save=True):

--- a/hpilo_cli
+++ b/hpilo_cli
@@ -60,6 +60,8 @@ def main():
                  help="Store XML output in this file")
     p.add_option('--read-response', dest="read_response", default=None, metavar='FILE',
                  help="Read XML response from this file instead of the iLO")
+    p.add_option('-s', '--ssl', dest="ssl_version", default="tls1",
+                 help="The SSL/TLS version to use for connecting to the iLO")
     p.add_option('-v', '--version', action="callback", callback=hpilo_version)
 
     opts, args = p.parse_args()
@@ -179,7 +181,13 @@ def main():
         'raw':   hpilo.ILO_RAW,
         'local': hpilo.ILO_LOCAL,
     }.get(opts.protocol, None)
-    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, len(calls) > 1)
+    opts.ssl_version = {
+        "tls1": "PROTOCOL_TLSv1",
+        "tls1_1" : "PROTOCOL_TLSv1_1",
+        "tls1_2" : "PROTOCOL_TLSv1_2",
+        "ssl3" : "PROTOCOL_SSLv3"
+    }.get(opts.ssl_version, "PROTOCOL_TLSv1")
+    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, len(calls) > 1, opts.ssl_version)
     ilo.debug = opts.debug
     ilo.save_response = opts.save_response
     ilo.read_response = opts.read_response

--- a/hpilo_cli
+++ b/hpilo_cli
@@ -52,6 +52,8 @@ def main():
                  help="Output debug information, repeat to see all XML data")
     p.add_option("-o", "--port", dest="port", type="int", default=443,
                  help="SSL port to connect to")
+    p.add_option('-s', '--ssl', dest="ssl_version", default="tls1",
+                 help="The SSL/TLS version to use for connecting to the iLO")
     p.add_option("-h", "--help", action="callback", callback=hpilo_help,
                  help="show this help message or help for a method")
     p.add_option("-H", "--help-methods", action="callback", callback=hpilo_help_methods,
@@ -60,8 +62,6 @@ def main():
                  help="Store XML output in this file")
     p.add_option('--read-response', dest="read_response", default=None, metavar='FILE',
                  help="Read XML response from this file instead of the iLO")
-    p.add_option('-s', '--ssl', dest="ssl_version", default="tls1",
-                 help="The SSL/TLS version to use for connecting to the iLO")
     p.add_option('-v', '--version', action="callback", callback=hpilo_version)
 
     opts, args = p.parse_args()
@@ -181,12 +181,8 @@ def main():
         'raw':   hpilo.ILO_RAW,
         'local': hpilo.ILO_LOCAL,
     }.get(opts.protocol, None)
-    opts.ssl_version = {
-        "tls1": "PROTOCOL_TLSv1",
-        "tls1_1" : "PROTOCOL_TLSv1_1",
-        "tls1_2" : "PROTOCOL_TLSv1_2",
-        "ssl3" : "PROTOCOL_SSLv3"
-    }.get(opts.ssl_version, "PROTOCOL_TLSv1")
+    opts.ssl_version = hpilo.SSL_VERSION.get(opts.ssl_version, None)
+
     ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, len(calls) > 1, opts.ssl_version)
     ilo.debug = opts.debug
     ilo.save_response = opts.save_response

--- a/tests/xml/fetch_responses
+++ b/tests/xml/fetch_responses
@@ -42,6 +42,8 @@ def main():
                  help="Output debug information, repeat to see all XML data")
     p.add_option("-o", "--port", dest="port", type="int", default=443,
                  help="SSL port to connect to")
+    p.add_option('-s', '--ssl', dest="ssl_version", default="tls1",
+                 help="The SSL/TLS version to use for connecting to the iLO")
 
     opts, args = p.parse_args()
 
@@ -84,7 +86,14 @@ def main():
         'local': hpilo.ILO_LOCAL,
     }.get(opts.protocol, None)
 
-    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol)
+    opts.ssl_version = {
+        "tls1": "PROTOCOL_TLSv1",
+        "tls1_1" : "PROTOCOL_TLSv1_1",
+        "tls1_2" : "PROTOCOL_TLSv1_2",
+        "ssl3" : "PROTOCOL_SSLv3"
+    }.get(opts.ssl_version, "PROTOCOL_TLSv1")
+
+    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, ssl_version=opts.ssl_version)
     ilo.debug = opts.debug
     if config.has_option('ilo', 'hponcfg'):
         ilo.hponcfg = config.get('ilo', 'hponcfg')

--- a/tests/xml/fetch_responses
+++ b/tests/xml/fetch_responses
@@ -85,13 +85,7 @@ def main():
         'raw':   hpilo.ILO_RAW,
         'local': hpilo.ILO_LOCAL,
     }.get(opts.protocol, None)
-
-    opts.ssl_version = {
-        "tls1": "PROTOCOL_TLSv1",
-        "tls1_1" : "PROTOCOL_TLSv1_1",
-        "tls1_2" : "PROTOCOL_TLSv1_2",
-        "ssl3" : "PROTOCOL_SSLv3"
-    }.get(opts.ssl_version, "PROTOCOL_TLSv1")
+    opts.ssl_version = hpilo.SSL_VERSION.get(opts.ssl_version, None)
 
     ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, ssl_version=opts.ssl_version)
     ilo.debug = opts.debug

--- a/tests/xml/generate_requests
+++ b/tests/xml/generate_requests
@@ -137,13 +137,7 @@ def main():
         'raw':   hpilo.ILO_RAW,
         'local': hpilo.ILO_LOCAL,
     }.get(opts.protocol, None)
-
-    opts.ssl_version = {
-        "tls1": "PROTOCOL_TLSv1",
-        "tls1_1" : "PROTOCOL_TLSv1_1",
-        "tls1_2" : "PROTOCOL_TLSv1_2",
-        "ssl3" : "PROTOCOL_SSLv3"
-    }.get(opts.ssl_version, "PROTOCOL_TLSv1")
+    opts.ssl_version = hpilo.SSL_VERSION.get(opts.ssl_version, None)
 
     ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, ssl_version=opts.ssl_version)
     ilo.debug = opts.debug

--- a/tests/xml/generate_requests
+++ b/tests/xml/generate_requests
@@ -94,6 +94,8 @@ def main():
                  help="Output debug information, repeat to see all XML data")
     p.add_option("-o", "--port", dest="port", type="int", default=443,
                  help="SSL port to connect to")
+    p.add_option('-s', '--ssl', dest="ssl_version", default="tls1",
+                 help="The SSL/TLS version to use for connecting to the iLO")
 
     opts, args = p.parse_args()
 
@@ -136,7 +138,14 @@ def main():
         'local': hpilo.ILO_LOCAL,
     }.get(opts.protocol, None)
 
-    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol)
+    opts.ssl_version = {
+        "tls1": "PROTOCOL_TLSv1",
+        "tls1_1" : "PROTOCOL_TLSv1_1",
+        "tls1_2" : "PROTOCOL_TLSv1_2",
+        "ssl3" : "PROTOCOL_SSLv3"
+    }.get(opts.ssl_version, "PROTOCOL_TLSv1")
+
+    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, ssl_version=opts.ssl_version)
     ilo.debug = opts.debug
     if config.has_option('ilo', 'hponcfg'):
         ilo.hponcfg = config.get('ilo', 'hponcfg')


### PR DESCRIPTION
… or --ssl_version to specify it

In iLOv4 with firmare 2.40 you can set the newest cipher ECDHE-RSA-AES256-SHA. This is supported with recent version of openssl_1 with at least TLSv1_1 protocol support.
This patch allow the user to specify via the new argument -s (or --ssl_version) the TLS protocol version to use. Following the naming used in the s_client tool from openssl, the allowed protocol are:

- tls1
- tls1_1
- tls1_2