### PR TITLE
Remove unused variables.

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -428,7 +428,7 @@ class Ilo(object):
         sock = self._get_socket()
         if self.read_response:
             protocol = sock.protocol
-        msglen = msglen_ = len(self.XML_HEADER + xml)
+        msglen = len(self.XML_HEADER + xml)
         if protocol == ILO_HTTP:
             extra_header = ''
             if self.cookie:

--- a/hpilo_fw.py
+++ b/hpilo_fw.py
@@ -98,7 +98,6 @@ def _parse(scexe, path, filename=None):
 
     tf = tarfile.open(name="bogus_name_for_old_python_versions", fileobj=BytesIO(tarball), mode='r:gz')
     filenames = [x for x in tf.getnames() if x.endswith('.bin')]
-    orig_filename = filename
     if not filename or filename not in filenames:
         if len(filenames) != 1:
             raise ValueError("scexe file seems corrupt")


### PR DESCRIPTION
Fix pyflakes errors.

hpilo_fw.py:101: local variable 'orig_filename' is assigned to but never used
hpilo.py:431: local variable 'msglen_' is assigned to but never used

Signed-off-by: Vinson Lee <vlee@freedesktop.org>