### PR TITLE
make mod_dir_config able to unset/remove values.

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -1493,7 +1493,7 @@ class Ilo(object):
 
         elements = []
         for key, val in vars.items():
-            if not val:
+            if val is None:
                 continue
             if key.endswith('_priv'):
                 if isinstance(val, basestring):


### PR DESCRIPTION
## Bugfix Pull Request
### Can't delete a value in mod_dir_config. I'm getting a "syntax error" response.
**Example**: hpilo_cli server1.loc mod_dir_config dir_grpacct2_sid=''
#### Before
##### for_bugreport.txt
HTTP/1.1
 200 OK
Content-Type: text/xml
Transfer-Encoding: chunked
Cache-Control: no-cache
Connection: close
Date: Tue, 13 Sep 2016 12:13:34 GMT
Server: HP-iLO-Server/1.30
X-Frame-Options: sameorigin

0e8
<?xml version="1.0"?>
<RIBCL VERSION="2.23">
<RESPONSE
    STATUS="0x0000"
    MESSAGE='No error'
     />
</RIBCL>
<?xml version="1.0"?>
<RIBCL VERSION="2.23">
<RESPONSE
    STATUS="0x0000"
    MESSAGE='No error'
     />
</RIBCL>

074
<?xml version="1.0"?>
<RIBCL VERSION="2.23">
<RESPONSE
    STATUS="0x0000"
    MESSAGE='No error'
     />
</RIBCL>

107
<?xml version="1.0"?>
<RIBCL VERSION="2.23">
<RESPONSE
    STATUS="0x0000"
    MESSAGE='No error'
     />
</RIBCL>
<?xml version="1.0"?>
<RIBCL VERSION="2.23">
<RESPONSE
    STATUS="0x0001"
    MESSAGE='Error: Line #1: syntax error near "/>".'
     />
</RIBCL>

0
##### XML Request
`<RIBCL VERSION="2.0"><LOGIN PASSWORD="***" USER_LOGIN="user1"><DIR_INFO MODE="write"><MOD_DIR_CONFIG /></DIR_INFO></LOGIN></RIBCL>`
### After Bugfix
##### XML Request
`<RIBCL VERSION="2.0"><LOGIN PASSWORD="********" USER_LOGIN="user1"><DIR_INFO MODE="write"><MOD_DIR_CONFIG><DIR_GRPACCT2_SID VALUE="" /></MOD_DIR_CONFIG></DIR_INFO></LOGIN></RIBCL>`
...
<RESPONSE
    STATUS="0x0000"
    MESSAGE='No error'
     />
</RIBCL>

\>\>\> my_ilo.mod_dir_config(dir_grpacct2_sid="")
