### PR TITLE
Added support for nand wear level checking

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -997,6 +997,9 @@ class Ilo(object):
         return self._info_tag('SERVER_INFO', 'GET_EMBEDDED_HEALTH', 'GET_EMBEDDED_HEALTH_DATA',
                 process=process)
 
+    def get_nand_vendor_data(self):
+        return self._info_tag('RIB_INFO', 'GET_NAND_VENDOR_DATA')
+
     # Ok, special XML structures. Yay.
     def _parse_get_embedded_health_data_drives(self, element):
         ret = []


### PR DESCRIPTION
After ilo version 2.44, there are improvements into the way the firmware wears on the hardware. Along with this version comes a way to check the wear levels. This is the correct xml schema to do this:

<RIB_INFO MODE="read"><GET_NAND_VENDOR_DATA /></RIB_INFO>

This patch adds this functionality to python-hpilo.

The output of this method is a dictionary such as the following:

{'mlc_wear_percentage': '20%',
 'nand_vendor': 'SanDisk',
 'slc_wear_percentage': '40%'}
