### PR TITLE
change proxy_host to proxy_url

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -1671,7 +1671,7 @@ class Ilo(object):
         """Set the server asset tag"""
         return self._control_tag('SERVER_INFO', 'SET_ASSET_TAG', attrib={'VALUE': asset_tag})
 
-    def set_ers_direct_connect(self, user_id, password, proxy_host=None,
+    def set_ers_direct_connect(self, user_id, password, proxy_url=None,
             proxy_port=None, proxy_username=None, proxy_password=None):
         """Register your iLO with HP Insigt Online using Direct Connect. Note
            that you must also call dc_registration_complete"""
@@ -1692,7 +1692,7 @@ class Ilo(object):
         ]
         return self._control_tag('RIB_INFO', 'SET_ERS_IRS_CONNECT', elements=elements)
 
-    def set_ers_web_proxy(self, proxy_host, proxy_port, proxy_username=None,
+    def set_ers_web_proxy(self, proxy_url, proxy_port, proxy_username=None,
             proxy_password=None):
         """Register your iLO with HP Insigt Online using Direct Connect. Note
            that you must also call dc_registration_complete"""


### PR DESCRIPTION
SET_ERS_DIRECT_CONNECT

Enter this command to begin the registration of your device to HPE Insight Online using Direct
Connect. You must have the Configure iLO Settings privilege to modify iLO Remote Support
settings, and a valid HP Passport Account is required to run this command. If you do not have
an account, sign up at http://www.hpe.com/info/insightonline.
For example:

``
<RIBCL VERSION="2.0">
<LOGIN USER_LOGIN="adminname" PASSWORD="password">
<RIB_INFO MODE="write">
<SET_ERS_DIRECT_CONNECT>
<ERS_HPP_USER_ID value="HpUID"/>
<ERS_HPP_PASSWORD value="HpPass"/>
<!-- if proxy is needed, enter the proxy information:
<ERS_WEB_PROXY_URL value="proxy.sample.hp.com"/>
<ERS_WEB_PROXY_PORT value="8080"/>
<ERS_WEB_PROXY_USERNAME value="proxy_user"/>
<ERS_WEB_PROXY_PASSWORD value="proxy_pass"/> -->
</SET_ERS_DIRECT_CONNECT>
</RIB_INFO>
</LOGIN>
</RIBCL>
``

After running SET_ERS_DIRECT_CONNECT, a final command is required to complete the
regisration process. See “DC_REGISTRATION_COMPLETE” (page 129) for more information