### PR TITLE
Fixing bug in mod_network_settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ firmware
 *.request.tmp
 hpilo_test_debug_output
 .firmware_version_cache
+.idea/

--- a/hpilo.py
+++ b/hpilo.py
@@ -1418,7 +1418,7 @@ class Ilo(object):
             timezone=None, enclosure_ip_enable=None, web_agent_ip_address=None,
             shared_network_port=None, vlan_enabled=None, vlan_id=None,
             shared_network_port_vlan=None, shared_network_port_vlan_id=None, ipv6_address=None,
-            ipv6_static_route_1=None, ipv6_static_route2=None, ipv6_static_route_3=None,
+            ipv6_static_route_1=None, ipv6_static_route_2=None, ipv6_static_route_3=None,
             ipv6_prim_dns_server=None, ipv6_sec_dns_server=None, ipv6_ter_dns_server=None,
             ipv6_default_gateway=None, ipv6_preferred_protocol=None, ipv6_addr_autocfg=None,
             ipv6_reg_ddns_server=None, dhcpv6_dns_server=None, dhcpv6_rapid_commit=None,

--- a/hpilo.py
+++ b/hpilo.py
@@ -1455,7 +1455,7 @@ class Ilo(object):
                     element.attrib['PREFIXLEN'] = '64'
         return self._control_tag('RIB_INFO', 'MOD_NETWORK_SETTINGS', elements=elements)
     mod_network_settings.requires_dict = ['static_route_1', 'static_route_2', 'static_route_3',
-        'ipv6_static_route_1', 'ipv6_static_route2', 'ipv6_static_route_3']
+        'ipv6_static_route_1', 'ipv6_static_route_2', 'ipv6_static_route_3']
 
     def mod_dir_config(self, dir_authentication_enabled=None,
             dir_local_user_acct=None,dir_server_address=None,


### PR DESCRIPTION
Noticed while using mod_network_settings that there was a minor typo. 

To follow convention, `ipv6_static_route2` should have been `ipv6_static_route_2`.