### PR TITLE
Validate certificates

### DIFF
--- a/docs/python.rst
+++ b/docs/python.rst
@@ -7,7 +7,7 @@ The :py:mod:`hpilo` module contains all you need to communicate with iLO
 devices, encapsulated in the :class:`Ilo` class and its methods. There are a
 few auxiliarry items in this module too.
 
-.. py:class:: Ilo(hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False, ssl_version=None)
+.. py:class:: Ilo(hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False, ssl_version=None, ca_file=None, match_hostname=True)
 
    Represents an iLO management interface on a specific host.
 
@@ -29,6 +29,12 @@ few auxiliarry items in this module too.
                    security layer, falling back to SSLv3 if necessary. You can
                    specify a different TLS version (use the constants from the
                    ssl module) to use if necessary.
+   :param ca_file: By default, the tls certificate of the iLO interfaces won't
+                   be validated. With this option set to a ca_bundle the
+                   certificate will be checked.
+   :param match_hostname: When ca_file is set, the hostname must match the
+                   commonname or SNI of the certificate. (IP Address
+                   matching doesn't work.) This option disables the matching.
 
    .. py:method:: call_delayed
 

--- a/hpilo.py
+++ b/hpilo.py
@@ -36,6 +36,8 @@ try:
 except ImportError:
     # Fallback for older python versions
     class ssl:
+        CERT_NONE        = 0
+        CERT_REQUIRED    = 2
         PROTOCOL_SSLv3   = 1
         PROTOCOL_SSLv23  = 2
         PROTOCOL_TLSv1   = 3
@@ -62,6 +64,9 @@ except ImportError:
 
         def close(self):
             return self.sock.close()
+
+        def match_hostname(self, peerCert, hostname):
+            pass
 
 try:
     import xml.etree.ElementTree as etree
@@ -216,7 +221,7 @@ class Ilo(object):
     HTTP_UPLOAD_HEADER = "POST /cgi-bin/uploadRibclFiles HTTP/1.1\r\nHost: localhost\r\nConnection: Close\r\nContent-Length: %d\r\nContent-Type: multipart/form-data; boundary=%s\r\n\r\n"
     BLOCK_SIZE = 64 * 1024
 
-    def __init__(self, hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False, ssl_version=None):
+    def __init__(self, hostname, login=None, password=None, timeout=60, port=443, protocol=None, delayed=False, ssl_version=None, ca_file=None, match_hostname=True):
         self.hostname = hostname
         self.login    = login or 'Administrator'
         self.password = password or 'Password'
@@ -236,6 +241,8 @@ class Ilo(object):
         self._protect_passwords = os.environ.get('HPILO_DONT_PROTECT_PASSWORDS', None) != 'YesPlease'
         self.firmware_mirror = None
         self.hponcfg = "/sbin/hponcfg"
+        self.ca_file = ca_file
+        self.match_hostname = match_hostname
         hponcfg = 'hponcfg'
         if platform.system() == 'Windows':
             self.hponcfg = 'C:\Program Files\HP Lights-Out Configuration Utility\cpqlocfg.exe'
@@ -427,7 +434,13 @@ class Ilo(object):
             raise IloCommunicationError("Unable to resolve %s" % self.hostname)
 
         try:
-            return ssl.wrap_socket(sock, ssl_version=self.ssl_version)
+            cert_reqs = ssl.CERT_NONE
+            if self.ca_file:
+              cert_reqs = ssl.CERT_REQUIRED
+            sslContext = ssl.wrap_socket(sock, ssl_version=self.ssl_version, cert_reqs=cert_reqs, ca_certs=self.ca_file)
+            if self.ca_file and self.match_hostname:
+              ssl.match_hostname(sslContext.getpeercert(), self.hostname)
+            return sslContext
         except socket.sslerror:
             e = sys.exc_info()[1]
             msg = getattr(e, 'reason', None) or getattr(e, 'message', None) or str(e)

--- a/hpilo_cli
+++ b/hpilo_cli
@@ -67,6 +67,10 @@ def main():
     p.add_option('--read-response', dest="read_response", default=None, metavar='FILE',
                  help="Read XML response from this file instead of the iLO")
     p.add_option('-v', '--version', action="callback", callback=hpilo_version)
+    p.add_option('--ca-file', dest="ca_file", default=None,
+                 help="CA bundle to validate iLO certificate against")
+    p.add_option('--no-match-hostname', dest="match_hostname", action='store_false', default=True,
+                 help="Don't check if the hostname matches the certificate when using --ca-file")
 
     opts, args = p.parse_args()
 
@@ -187,7 +191,7 @@ def main():
     }.get(opts.protocol, None)
     opts.ssl_version = getattr(hpilo.ssl, 'PROTOCOL_' + opts.ssl_version.upper().replace('V','v'))
 
-    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, len(calls) > 1, opts.ssl_version)
+    ilo = hpilo.Ilo(hostname, login, password, opts.timeout, opts.port, opts.protocol, len(calls) > 1, opts.ssl_version, opts.ca_file, opts.match_hostname)
     ilo.debug = opts.debug
     ilo.save_response = opts.save_response
     ilo.read_response = opts.read_response


### PR DESCRIPTION
Add the ability to validate the certificate of the iLO interface.
This addition doesn't change the default behavior.

This addresses #146. 