### PR TITLE
Add ilo2_230 and ilo3_189

### DIFF
--- a/firmware.conf
+++ b/firmware.conf
@@ -49,9 +49,9 @@ url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p198079150
 file = ilo196.bin
 
 [ilo2]
-version = 2.29
-url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p915269625/v112310/CP027871.scexe
-file = ilo2_229.bin
+version = 2.30
+url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p915269625/v128193/CP032232.scexe
+file = ilo2_230.bin
 
 [ilo2 1.20]
 version = 1.20
@@ -243,10 +243,15 @@ version = 2.29
 url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p915269625/v112310/CP027871.scexe
 file = ilo2_229.bin
 
+[ilo2 2.30]
+version = 2.30
+url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p915269625/v128193/CP032232.scexe
+file = ilo2_230.bin
+
 [ilo3]
-version = 1.88
-url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1573561412/v116231/CP029099.scexe
-file = ilo3_188.bin
+version = 1.89
+url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1573561412/v127869/CP032172.scexe
+file = ilo3_189.bin
 
 [ilo3 1.00]
 version = 1.00
@@ -337,6 +342,11 @@ file = ilo3_187.bin
 version = 1.88
 url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1573561412/v116231/CP029099.scexe
 file = ilo3_188.bin
+
+[ilo3 1.89]
+version = 1.89
+url = http://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1573561412/v127869/CP032172.scexe
+file = ilo3_189.bin
 
 [ilo4]
 version = 2.55


### PR DESCRIPTION
I am maintaining pingtool.org website where users sometimes report newly released ilo versions.
There is also new firmware for iLO3 - 1.89, however no Linux version released yet.