### PR TITLE
Send SNMP Test Trap bugfix

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -1624,7 +1624,7 @@ class Ilo(object):
 
     def send_snmp_test_trap(self):
         """Send an SNMP test trap to the configured alert destinations"""
-        return self._control_tag('RIB_INFO', 'SEND_SNMP_TEST_TAG')
+        return self._control_tag('RIB_INFO', 'SEND_SNMP_TEST_TRAP')
 
     def set_ahs_status(self, status):
         """Enable or disable AHS logging"""


### PR DESCRIPTION
This should fix #165 

There appeared to be a typo in the send_snmp_test_trap function. It was `SEND_SNMP_TEST_TAG` but should have been `SEND_SNMP_TEST_TEST`.

This was causing the iLO to return this error
`syntax error near "SEND_SNMP_TEST_TAG".. You may have tried to use a feature this iLO version or firmware version does not support`
