### PR TITLE
fix problem with delayed call, if one function is not supported see #172

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -579,6 +579,8 @@ class Ilo(object):
                         # This is triggered when doing protocol detection, ignore
                         pass
                     else:
+                        self._processors = []
+                        self._elements = None
                         status = int(child.get('STATUS'), 16)
                         message = child.get('MESSAGE')
                         if 'syntax error' in message:


### PR DESCRIPTION
if wrapped in try,except block, the ilo class would not clean up the failed requests and therefore every subsequent call with ilo.call_delayed() would fail too