### PR TITLE
Add ilo3 version 1.20 firmware

### DIFF
--- a/firmware.conf
+++ b/firmware.conf
@@ -293,6 +293,11 @@ version = 1.16
 url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1255562964/v65714/CP014254.scexe
 file = ilo3_116.bin
 
+[ilo3 1.20]
+version = 1.20
+url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1255562964/v64722/CP014002.scexe
+file = ilo3_120.bin
+
 [ilo3 1.26]
 version = 1.26
 url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1255562964/v70182/CP015458.scexe


### PR DESCRIPTION
HP installation instructions for the latest ilo3 firmware version (https://support.hpe.com/hpsc/swd/public/detail?sp4ts.oid=5294355&swItemId=MTX_1b88d375e39c4da586e62e5750&swEnvOid=4184#tab2) say "Customers running a version of iLO 3 previous to v1.20 must upgrade to v1.20 before upgrading to this version."