### PR TITLE
ilo5 1.37

### DIFF
--- a/firmware.conf
+++ b/firmware.conf
@@ -529,9 +529,9 @@ url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p19212242
 file = ilo4_261.bin
 
 [ilo5]
-version = 1.35
-url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1342933511/v153199/CP036661.scexe
-file = ilo5_135.bin
+version = 1.37
+url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1342933511/v157138/CP037568.scexe
+file = ilo5_137.bin
 
 [ilo5 1.20]
 version = 1.20
@@ -547,3 +547,8 @@ file = ilo5_130.bin
 version = 1.35
 url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1342933511/v153199/CP036661.scexe
 file = ilo5_135.bin
+
+[ilo5 1.37]
+version = 1.37
+url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1342933511/v157138/CP037568.scexe
+file = ilo5_137.bin


### PR DESCRIPTION
New iLO5 version 1.37 (SECURITY FIXES: HPESBHF03894 - HPE iLO5 Local Bypass of Security Restrictions in Firmware Update)