### PR TITLE
Ilo4: add reference to 2.62 & 2.70

### DIFF
--- a/firmware.conf
+++ b/firmware.conf
@@ -379,9 +379,9 @@ url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p15735614
 file = ilo3_191.bin
 
 [ilo4]
-version = 2.61
-url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v154294/CP036949.scexe
-file = ilo4_261.bin
+version = 2.70
+url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v158634/CP037959.scexe
+file = ilo4_270.bin
 
 [ilo4 1.01]
 version = 1.01
@@ -532,6 +532,16 @@ file = ilo4_260.bin
 version = 2.61
 url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v154294/CP036949.scexe
 file = ilo4_261.bin
+
+[ilo4 2.62]
+version = 2.62
+url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v160135/CP038290.scexe
+file = ilo4_262.bin
+
+[ilo4 2.70]
+version = 2.70
+url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v158634/CP037959.scexe
+file = ilo4_270.bin
 
 [ilo5]
 version = 1.39


### PR DESCRIPTION
Firmware.conf is updated with reference to
ilo4 2.62 & 2.70