### PR TITLE
Allow "*_priv" vars in mod_dir_config to be single digit

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -1605,7 +1605,7 @@ class Ilo(object):
             if key.endswith('_priv'):
                 if isinstance(val, basestring):
                     val = val.replace('oemhp_', '').replace('_priv', '').split(',')
-                if isinstance(val, list):
+                if isinstance(val, (list, tuple, set)):
                     val = ','.join([str(privmap.get(x,x)) for x in val])
                 if not isinstance(val, basestring):
                     val = str(privmap.get(val,val))

--- a/hpilo.py
+++ b/hpilo.py
@@ -1605,7 +1605,10 @@ class Ilo(object):
             if key.endswith('_priv'):
                 if isinstance(val, basestring):
                     val = val.replace('oemhp_', '').replace('_priv', '').split(',')
-                val = ','.join([str(privmap.get(x,x)) for x in val])
+                if isinstance(val, list):
+                    val = ','.join([str(privmap.get(x,x)) for x in val])
+                if not isinstance(val, basestring):
+                    val = str(privmap.get(val,val))
             else:
                 val = str({True: 'Yes', False: 'No'}.get(val, val))
             elements.append(etree.Element(key.upper(), VALUE=val))


### PR DESCRIPTION
Currently the privileges in mod_dir_config need to be
comma separated to be accepted. This will not work for single
privileges like "1" or "6".

This commit fixes this.