### PR TITLE
Fix '\x01' in malformed XML output

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -558,6 +558,11 @@ class Ilo(object):
 
         if '<RIBCL VERSION="2.22"/>' in data:
             data = data.replace('<RIBCL VERSION="2.22"/>', '<RIBCL VERSION="2.22">')
+
+        # Remove binary 01 in xml output. This bug was seen on a faulty PSU.
+        if '\x01' in data:
+            data = data.replace('\x01', '')
+        
         # Quite a few unescaped quotation mark bugs keep appearing. Let's try
         # to fix up the XML by replacing the last occurence of a quotation mark
         # *before* the position of the error.


### PR DESCRIPTION
Hi,

one of our servers has an invalid xml output with '\x01'/^A in it. This fixes the xml.

````
<SUPPLY>
     <LABEL VALUE = "Power Supply 1"/>
     <PRESENT VALUE = "Yes"/>
     <STATUS VALUE = "Good, In Use"/>
     <PDS VALUE = "No"/>
     <HOTPLUG_CAPABLE VALUE = "Yes"/>
     <MODEL VALUE = "720478-B21"/>
     <SPARE VALUE = "^A"/>
     <SERIAL_NUMBER VALUE = "censored"/>
     <CAPACITY VALUE = "500 Watts"/>
     <FIRMWARE_VERSION VALUE = "2.00"/>
</SUPPLY>
````