### PR TITLE
Add iLO4 2.75

### DIFF
--- a/firmware.conf
+++ b/firmware.conf
@@ -389,9 +389,9 @@ url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p15735614
 file = ilo3_193.bin
 
 [ilo4]
-version = 2.73
-url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v176128/CP042663.scexe
-file = ilo4_273.bin
+version = 2.75
+url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v182737/CP044405.scexe
+file = ilo4_275.bin
 
 [ilo4 1.01]
 version = 1.01
@@ -562,6 +562,11 @@ file = ilo4_272.bin
 version = 2.73
 url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v176128/CP042663.scexe
 file = ilo4_273.bin
+
+[ilo4 2.75]
+version = 2.75
+url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p192122427/v182737/CP044405.scexe
+file = ilo4_275.bin
 
 [ilo5]
 version = 1.39


### PR DESCRIPTION
No trace of iLO4 2.74 on HPE Side
Fixes Ripple20 (Critical Update)