### PR TITLE
Support HPE fwpkg firmware packaging

### DIFF
--- a/hpilo_fw.py
+++ b/hpilo_fw.py
@@ -7,6 +7,7 @@ import tarfile
 import io
 import os
 import sys
+from zipfile import ZipFile
 PY3 = sys.version_info[0] >= 3
 
 if PY3:
@@ -50,6 +51,9 @@ def download(ilo, path=None, progress = lambda txt: None):
         if conf[ilo]['url'].endswith('.bin'):
             with open(os.path.join(path, conf[ilo]['file']), 'wb') as fd:
                 fd.write(data)
+        elif conf[ilo]['url'].endswith('.fwpkg'):
+            with ZipFile(io.BytesIO(data)) as zipObj:
+                zipObj.extract(conf[ilo]['file'], path)
         else:
             _parse(data, path, conf[ilo]['file'])
         return True


### PR DESCRIPTION
iLO5 are now delivered through this format on HPE support site.
This a simple Zip file containing the .bin file and few extra files.

This simple patch extract the .bin in the Zip.

Sample content of a fwpkg file:

Archive:  ilo5_218.fwpkg
  inflating: ilo5_218.bin
  inflating: ilo5_218.xml
  inflating: payload.json
  inflating: readme.txt