### PR TITLE
Support iLO5 2.18 in fwpkg format

### DIFF
--- a/firmware.conf
+++ b/firmware.conf
@@ -569,9 +569,9 @@ url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p19212242
 file = ilo4_275.bin
 
 [ilo5]
-version = 1.39
-url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1342933511/v159725/CP038198.scexe
-file = ilo5_139.bin
+version = 2.18
+url = https://downloads.hpe.com/pub/softlib2/software1/fwpkg-ilo/p991377599/v183732/ilo5_218.fwpkg
+file = ilo5_218.bin
 
 [ilo5 1.20]
 version = 1.20
@@ -597,3 +597,8 @@ file = ilo5_137.bin
 version = 1.39
 url = https://downloads.hpe.com/pub/softlib2/software1/sc-linux-fw-ilo/p1342933511/v159725/CP038198.scexe
 file = ilo5_139.bin
+
+[ilo5 2.18]
+version = 2.18
+url = https://downloads.hpe.com/pub/softlib2/software1/fwpkg-ilo/p991377599/v183732/ilo5_218.fwpkg
+file = ilo5_218.bin


### PR DESCRIPTION
This patch requires the fwpkg support to be
merged first.