### PR TITLE
Fix error with python 3.9

### DIFF
--- a/hpilo.py
+++ b/hpilo.py
@@ -684,7 +684,7 @@ class Ilo(object):
             retval[key.lower()] = self._coerce(val)
         if list(element):
             fields = []
-            for child in element.getchildren():
+            for child in element:
                 if child.tag == 'FIELD':
                     fields.append(self._element_to_dict(child))
             if fields:


### PR DESCRIPTION
AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'
getchildren() has been removed in python 3.9

Signed-off-by: Etienne Champetier <echampetier@anevia.com>