### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -47,7 +47,7 @@ Occasionally you might see this error at the end of a traceback::
 
   hpilo.IloError: Error communicating with iLO: Syntax error: Line #0: syntax error near "" in the line: ""
 
-This generaly means that you are trying to call a method that is not supported
+This generally means that you are trying to call a method that is not supported
 for your device or the firmware version you use. Get this information with::
 
   hpilo_cli example-server.int.kaarsemaker.net get_fw_version
@@ -62,7 +62,7 @@ SSL: SSLV3_ALERT_HANDSHAKE_FAILURE] sslv3 alert handshake failure (_ssl.c:661)
 ------------------------------------------------------------------------------
 Your operating system vendor wisely doesn't support older SSL protocols
 anymore, and your iLO firmware is too old. Try using an older version of your
-os, possibly in a vm, chroot or container to ugrade the firmware of your iLO
+os, possibly in a vm, chroot or container to upgrade the firmware of your iLO
 
 ElementTree.ParseError
 -----------------------
@@ -103,9 +103,9 @@ first update to 1.40 and then update to a later version::
 `hpilo.IloError: Error reading configuration`
 ---------------------------------------------
 This error might occur in delayed mode when one of the calls causes a reset of
-the iLO, such as changing network settings or reseting to factory defaults. All
+the iLO, such as changing network settings or resetting to factory defaults. All
 delayed calls called by the same `call_delayed` after this reset may then cause
-this error as the iLO is reseting. For example, when calling `hpilo_cli
+this error as the iLO is resetting. For example, when calling `hpilo_cli
 localhost factory_defaults + activate_license key=12345`, the
 `activate_license` call may fail with this error. If you hit this issue and you
 use calls that can cause a reset, make sure you either use them outside a

--- a/hpilo.py
+++ b/hpilo.py
@@ -564,7 +564,7 @@ class Ilo(object):
             data = data.replace('\x01', '')
         
         # Quite a few unescaped quotation mark bugs keep appearing. Let's try
-        # to fix up the XML by replacing the last occurence of a quotation mark
+        # to fix up the XML by replacing the last occurrence of a quotation mark
         # *before* the position of the error.
         #
         # Definitely not an optimal algorithm, but this is not a hot path.
@@ -1176,7 +1176,7 @@ class Ilo(object):
         return self._info_tag('RIB_INFO', 'GET_FEDERATION_GROUP', attrib={'GROUP_NAME': group_name}, process=process)
 
     def get_federation_multicast(self):
-        """Get the iLO federation mulicast settings"""
+        """Get the iLO federation multicast settings"""
         return self._info_tag('RIB_INFO', 'GET_FEDERATION_MULTICAST')
 
     def get_fips_status(self):
@@ -1723,7 +1723,7 @@ class Ilo(object):
         return self._control_tag('SSO_INFO', 'MOD_SSO_SETTINGS', elements=elements)
 
     def mod_twofactor_settings(self, auth_twofactor_enable=None, cert_revocation_check=None, cert_owner_san=None, cert_owner_subject=None):
-        """Modify the twofactor authenticatino settings"""
+        """Modify the twofactor authentication settings"""
         elements = []
         if auth_twofactor_enable is not None:
             elements.append(etree.Element('AUTH_TWOFACTOR_ENABLE', VALUE=['No', 'Yes'][bool(auth_twofactor_enable)]))
@@ -1956,7 +1956,7 @@ class Ilo(object):
 
     def set_server_auto_pwr(self, setting):
         """Set the automatic power on delay setting. Valid settings are False,
-           True (for minumum delay), 15, 30, 45 60 (for that amount of delay)
+           True (for minimum delay), 15, 30, 45 60 (for that amount of delay)
            or random (for a random delay of up to 60 seconds.)"""
         setting = str({True: 'Yes', False: 'No'}.get(setting, setting))
         return self._control_tag('SERVER_INFO', 'SERVER_AUTO_PWR', attrib={'VALUE': setting})


### PR DESCRIPTION
There are small typos in:
- docs/troubleshooting.rst
- hpilo.py

Fixes:
- Should read `upgrade` rather than `ugrade`.
- Should read `resetting` rather than `reseting`.
- Should read `occurrence` rather than `occurence`.
- Should read `multicast` rather than `mulicast`.
- Should read `minimum` rather than `minumum`.
- Should read `generally` rather than `generaly`.
- Should read `authentication` rather than `authenticatino`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md